### PR TITLE
Ch 02 - 5-subsetting_data fix Regex pattern

### DIFF
--- a/ch_02/5-subsetting_data.ipynb
+++ b/ch_02/5-subsetting_data.ipynb
@@ -2127,7 +2127,7 @@
    ],
    "source": [
     "df.loc[\n",
-    "    (df.place.str.contains(r'CA|California$')) & (df.mag > 3.8),\n",
+    "    (df.place.str.contains(r'(CA|California)$')) & (df.mag > 3.8),\n",
     "    ['alert', 'mag', 'magType', 'title', 'tsunami', 'type']\n",
     "]"
    ]


### PR DESCRIPTION
Fix Regex pattern to match CA at the end or California at the end.

Current pattern would match CA anywhere in string or California at the end. Can confirm behavior is not as described in the book by running an example with r"Ca|California$".